### PR TITLE
Left side margin with white on black colours

### DIFF
--- a/filedefs/filetypes.common
+++ b/filedefs/filetypes.common
@@ -13,8 +13,12 @@ brace_good=0xffffff;0x50AA15;true;false
 brace_bad=0xffffff;0xAA1515;true;false
 
 # the following settings define the colours of the margins on the left side
-margin_linenumber=0x000000;0xd0d0d0;false;false
-margin_folding=0x000000;0xdfdfdf;false;false
+# black on white
+#margin_linenumber=0x000000;0xd0d0d0;false;false
+#margin_folding=0x000000;0xdfdfdf;false;false
+# white on black
+margin_linenumber=0xeee;0x1A1A1A;false;false
+margin_folding=0x888a85;0x1A1A1A;false;false
 
 # background colour of the current line, only the second and third argument is interpreted
 # use the third argument to enable or disable the highlighting of the current line (has to be true/false)

--- a/filedefs/filetypes.common
+++ b/filedefs/filetypes.common
@@ -1,7 +1,7 @@
 # For complete documentation of this file, please see Geany's main documentation
 [styling]
 # foreground;background;bold;italic - used for filetype All/None
-default=0xffffff;0x1E1E1E;false;false
+default=0xCCCCCC;0x1E1E1E;false;false
 
 # 3rd selection argument is true to override default foreground
 # 4th selection argument is true to override default background
@@ -17,7 +17,7 @@ brace_bad=0xffffff;0xAA1515;true;false
 #margin_linenumber=0x000000;0xd0d0d0;false;false
 #margin_folding=0x000000;0xdfdfdf;false;false
 # white on black
-margin_linenumber=0xeee;0x1A1A1A;false;false
+margin_linenumber=0xCCCCCC;0x1A1A1A;false;false
 margin_folding=0x888a85;0x1A1A1A;false;false
 
 # background colour of the current line, only the second and third argument is interpreted


### PR DESCRIPTION
This pull request changes the colours of the left side margin from "black on white" to "white on black".

A left margin with a white (light) background only goes well with light OS themes. It spoils a dark OS theme. On the other hand, a black (dark) margin goes well with both light and dark OS themes. Please check the following screenshots:

Light margin on a dark OS theme:
![light-margin-dark-os](https://cloud.githubusercontent.com/assets/1716156/8609809/00d7e3d0-26a2-11e5-927a-b7ae92e0fcbb.png)
The light margin on the middle of the screen emits too much light affecting the readability of the code displayed over a dark background.

Dark margin on a dark OS theme:
![dark-margin-dark-os](https://cloud.githubusercontent.com/assets/1716156/8609832/47879fc8-26a2-11e5-9d30-77eb32f303c7.png)
Perfect.

Dark margin on a light OS theme:
![dark-margin-light-os](https://cloud.githubusercontent.com/assets/1716156/8609838/5af57eae-26a2-11e5-9d96-c5dfb37a2726.png)
Not bad because geany-dark-scheme already turns the code background into a dark colour,
